### PR TITLE
added NSImage extension here since this library is the only one that uses it. Need to determine how to proceed when not working strictly with Mac apps, however.

### DIFF
--- a/Sources/SwiftID3Tagger/Extensions/NSImage.swift
+++ b/Sources/SwiftID3Tagger/Extensions/NSImage.swift
@@ -1,0 +1,38 @@
+//
+//  File.swift
+//  
+//
+//  Created by Nolaine Crusher on 11/2/20.
+//
+
+import Foundation
+import Cocoa
+
+extension NSImage {
+    
+    /// Converts an `NSImage` to png data
+    var pngData: Data {
+        if let tiff = tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiff),
+           let data = bitmap.representation(using: .png, properties: [.compressionFactor: 1.0]) {
+            return data
+        } else {
+            // Not sure if this situation can ever happen anyway.
+            // If it does turn out to be possible, this should be turned into a thrown error instead.
+            fatalError("Unable to convert image to PNG.")
+        }
+    }
+    
+    /// Converts an `NSImage` to jpg data
+    var jpgData: Data {
+        if let tiff = tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiff),
+           let data = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 1.0]) {
+            return data
+        } else {
+            // Not sure if this situation can ever happen anyway.
+            // If it does turn out to be possible, this should be turned into a thrown error instead.
+            fatalError("Unable to convert image to JPG.")
+        }
+    }
+}


### PR DESCRIPTION
So, I just encountered an issue that I probably should have anticipated earlier.

A bit of background: I'm a little stuck on `Audiobook Liberator` for the moment, because I honestly can't remember why I thought it was needful or even a good idea to do things like caching metadata from that app when it's supposed to be a straightforward conversion/DRM-decryption tool.

Also, if I were to make that app a Ipad app with Mac Catalyst instead of a straight-up Mac App, I could use MobileFFmpeg instead of bundling FFmpeg in the app, and if I can ever get anyone to reply to me, it's possible that CryptoSwift might be an alternative to RCrack, which means that I wouldn't have to bundle ANYTHING in with the app, it could all be done using libraries, which seems much cleaner but would require a bit of walking things back and redoing them using tools that either didn't exist, or that I didn't understand how to use, back when I started.

I get that a year ago, when I was making these decisions, I didn't know as much as I do now, but still that's kind of a bitter pill to swallow and I'm still trying to figure out how I feel about it all and how I want to proceed.

In the meantime, though, it's been a year, and I really should probably create something that I can actually put up on the App store or request donations on or...something. Because bills.

So, the issue I encountered. Today I started poking at SwiftUI and MacCatalyst with the idea of moving ahead with my library management app (`AudiobookLibrarian`), while I'm figuring out how I want to handle things with `Audiobook Liberator`, and I discoverted that the way I handle converting images to data isn't going to work if I try to work with Mac Catalyst.

```Swift
    /// Converts an `NSImage` to png data
    var pngData: Data {
        if let tiff = tiffRepresentation,
           let bitmap = NSBitmapImageRep(data: tiff),
           let data = bitmap.representation(using: .png, properties: [.compressionFactor: 1.0]) {
            return data
        } else {
            // Not sure if this situation can ever happen anyway.
            // If it does turn out to be possible, this should be turned into a thrown error instead.
            fatalError("Unable to convert image to PNG.")
        }
    }

// and also a corresponding jpgData property 
```

Because it looks like `tiffRepresentation/NSBitmapImageRep` isn't available for Mac Catalyst. I could just go ahead and mac it a pure Mac app, but sooner or later, I'm going to want to create an iOS version of my library management app and I'm going to have to deal with the fact that my image handling here is Cocoa-based and not compatible with iOS.

But this is the first time since doing the early "build your first app" tutorials over a year ago that I've even looked at iOS and frankly I don't remember much, and I don't believe any of those tutorials ever covered how to make an app cross-platform compatible.