### PR TITLE
Exporting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftConvenienceExtensions",
+        "repositoryURL": "https://github.com/NCrusher74/SwiftConvenienceExtensions",
+        "state": {
+          "branch": null,
+          "revision": "786cf2493e067b2ac154a3c7da5d967ca1ff89f3",
+          "version": "2.0.9"
+        }
+      },
+      {
+        "package": "SwiftLanguageAndLocaleCodes",
+        "repositoryURL": "https://github.com/NCrusher74/SwiftLanguageAndLocaleCodes",
+        "state": {
+          "branch": null,
+          "revision": "6f3a3fa43e96db0c2e9aecf8a4891e9ba4964b9b",
+          "version": "2.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/NCrusher74/SwiftConvenienceExtensions",
         "state": {
           "branch": null,
-          "revision": "786cf2493e067b2ac154a3c7da5d967ca1ff89f3",
-          "version": "2.0.9"
+          "revision": "a789e32038031a4742d4673eba1e07edf24b03b8",
+          "version": "3.0.15"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             from: "2.0.0"),
         .package(
             url: "https://github.com/NCrusher74/SwiftConvenienceExtensions",
-            from: "2.0.0"),
+            from: "3.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftTaggerID3/Extensions/String.Encoding.swift
+++ b/Sources/SwiftTaggerID3/Extensions/String.Encoding.swift
@@ -11,10 +11,8 @@ import Foundation
 
 extension String.Encoding {
     init(byte: Data?) throws {
-        if byte == nil {
-            self = .ascii
-        } else {
-            let uInt8 = byte?.uInt8BE
+        if let byte = byte {
+            let uInt8 = byte.uInt8BE
             switch uInt8 {
                 case 0x00: self = .isoLatin1
                 case 0x01: self = .utf16
@@ -22,6 +20,8 @@ extension String.Encoding {
                 case 0x03: self = .utf8
                 default: throw Mp3FileError.InvalidStringEncodingByte
             }
+        } else {
+            self = .ascii
         }
     }
     

--- a/Sources/SwiftTaggerID3/Extensions/String.swift
+++ b/Sources/SwiftTaggerID3/Extensions/String.swift
@@ -115,34 +115,7 @@ extension String {
         return dateComponents.date
     }
     
-    
-    @available(OSX 10.12, iOS 12.0, *)
-    func attemptDateFromString() -> Date? {
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
-        isoFormatter.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
         
-        let formats: [String] = ["d MMM yyyy HH:mm:ss", "yyyy-MM-ddTHH:mm", "yyyy-MM-ddTHH:mm:ssZ", "MM-dd-yyyy HH:mm","yyyy-MM-ddTHH", "MMM d, yyyy", "d MMM yyyy", "yyyy-MM-dd", "MM/dd/yyyy", "dd/MM/yyyy", "dd.MM.yy", "dd.MM.yyyy", "dd-MM-yy", "dd-MM-yyyy", "dd-MMM-yyyy", "dd-MMM-yy", "MM-dd-yyyy", "MMMM yyyy", "yyyy-MM"]
-        let dateFormatters: [DateFormatter] = formats.map { format in
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.dateFormat = format
-            return formatter
-        }
-
-        if let date = isoFormatter.date(from: self) {
-            return date
-        } else {
-            for format in dateFormatters {
-                if let date = format.date(from: self) {
-                    return date
-                } else {
-                    return nil
-                }
-            }; return nil
-        }
-    }
-    
     /// parse the parentheses out of version 2.2 and 2.3 strings (Genre and MediaType frames)
     /// for PresetOptionsFrame
     func parseParentheticalString() -> [String] {

--- a/Sources/SwiftTaggerID3/Frame/Frame.swift
+++ b/Sources/SwiftTaggerID3/Frame/Frame.swift
@@ -18,9 +18,9 @@ import Foundation
  */
 public class Frame: CustomStringConvertible {
     public var description: String {
-        return self.identifier.rawValue
+        fatalError("Override from metadata atom \(identifier.rawValue)")
     }
-    
+
     var identifier: FrameIdentifier
     var version: Version
     var size: Int
@@ -39,16 +39,14 @@ public class Frame: CustomStringConvertible {
     var frameKey: FrameKey {
         switch self.identifier {
             case .attachedPicture, .chapter, .comments, .unsynchronizedLyrics, .userDefinedText, .userDefinedWebpage, .passThrough:
-                fatalError("Override from frame subclass is required")
+                fatalError("Override frameKey in subclass \(type(of: self))")
             default: return self.identifier.frameKey
         }
     }
-
     
     var contentData: Data {
-        fatalError("Override from frame subclass is required")
+        fatalError("Override contentData in subclass \(type(of: self))")
     }
-    
     
     var encode: Data {
         guard self.contentData != Data() else {
@@ -78,7 +76,6 @@ public class Frame: CustomStringConvertible {
     /// - Returns:
     ///   - Version 2.2: three bytes of frame-size data.
     ///   - Versions 2.3 & 2.4: four bytes of frame-size data
-    
     private var encodedFrameContentSize: Data {
         let contentSize = self.contentData.count.uInt32
         switch self.version {

--- a/Sources/SwiftTaggerID3/Frame/FrameIdentifier.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameIdentifier.swift
@@ -11,8 +11,7 @@ import Foundation
 import SwiftLanguageAndLocaleCodes
 
 /// An enumeration of ID3 standard--or iTunes compliant but non-standard--frames
-enum FrameIdentifier: String, CaseIterable {
-    
+enum FrameIdentifier: String, CaseIterable {    
     case album
     case albumSort
     case albumArtist
@@ -120,18 +119,21 @@ enum FrameIdentifier: String, CaseIterable {
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
         }
     }
+    
     func frameKey(idString: String, uuid: UUID) -> FrameKey {
         switch self {
             case .passThrough: return .passThrough(idString: idString, uuid: uuid)
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
         }
     }
+    
     func frameKey(imageType: ImageType) -> FrameKey {
         switch self {
             case .attachedPicture: return .attachedPicture(imageType: imageType)
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
         }
     }
+    
     func frameKey(language: ISO6392Code?, description: String?) -> FrameKey {
         let language = language ?? .und
         let description = description ?? ""
@@ -141,6 +143,7 @@ enum FrameIdentifier: String, CaseIterable {
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
         }
     }
+    
     func frameKey(_ description: String?) -> FrameKey {
         let description = description ?? ""
         switch self {
@@ -149,6 +152,7 @@ enum FrameIdentifier: String, CaseIterable {
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
         }
     }
+    
     var frameKey: FrameKey {
         switch self {
             case .album: return .album
@@ -220,6 +224,86 @@ enum FrameIdentifier: String, CaseIterable {
             case .trackNumber: return .trackNumber
             case .year: return .year
             default: fatalError("Wrong frame key for identifier \(self.rawValue)")
+        }
+    }
+    
+    init(frameKey: FrameKey) {
+        switch frameKey {
+            case .album: self = .album
+            case .albumArtist: self = .albumArtist
+            case .albumArtistSort: self = .albumArtistSort
+            case .albumSort: self = .albumSort
+            case .arranger: self = .arranger
+            case .artist: self = .artist
+            case .artistSort: self = .artistSort
+            case .artistWebpage: self = .artistWebpage
+            case .attachedPicture(imageType: _): self = .attachedPicture
+            case .audioFileWebpage: self = .audioFileWebpage
+            case .audioSourceWebpage: self = .audioSourceWebpage
+            case .bpm: self = .bpm
+            case .chapter(startTime: _): self = .chapter
+            case .comments(language: _, description: _): self = .comments
+            case .compilation: self = .compilation
+            case .composer: self = .composer
+            case .composerSort: self = .composerSort
+            case .conductor: self = .conductor
+            case .contentGroup: self = .contentGroup
+            case .copyright: self = .copyright
+            case .copyrightWebpage: self = .copyrightWebpage
+            case .date: self = .date
+            case .discNumber: self = .discNumber
+            case .encodingDateTime: self = .encodingDateTime
+            case .encodedBy: self = .encodedBy
+            case .encodingSettings: self = .encodingSettings
+            case .fileType: self = .fileType
+            case .fileOwner: self = .fileOwner
+            case .genre: self = .genre
+            case .grouping: self = .grouping
+            case .initialKey: self = .initialKey
+            case .involvedPeopleList: self = .involvedPeopleList
+            case .isrc: self = .isrc
+            case .languages: self = .languages
+            case .length: self = .length
+            case .lyricist: self = .lyricist
+            case .mediaType: self = .mediaType
+            case .mood: self = .mood
+            case .movementCount: self = .movementCount
+            case .movement: self = .movement
+            case .movementNumber: self = .movementNumber
+            case .musicianCreditsList: self = .musicianCreditsList
+            case .originalAlbum: self = .originalAlbum
+            case .originalArtist: self = .originalArtist
+            case .originalFilename: self = .originalFilename
+            case .originalLyricist: self = .originalLyricist
+            case .originalReleaseDateTime: self = .originalReleaseDateTime
+            case .paymentWebpage: self = .paymentWebpage
+            case .playlistDelay: self = .playlistDelay
+            case .podcastCategory: self = .podcastCategory
+            case .podcastDescription: self = .podcastDescription
+            case .podcastID: self = .podcastID
+            case .podcastKeywords: self = .podcastKeywords
+            case .podcastFeed: self = .podcastFeed
+            case .producedNotice: self = .producedNotice
+            case .publisher: self = .publisher
+            case .publisherWebpage: self = .publisherWebpage
+            case .radioStation: self = .radioStation
+            case .radioStationOwner: self = .radioStationOwner
+            case .radioStationWebpage: self = .radioStationWebpage
+            case .recordingDateTime: self = .recordingDateTime
+            case .releaseDateTime: self = .releaseDateTime
+            case .setSubtitle: self = .setSubtitle
+            case .subtitle: self = .subtitle
+            case .tableOfContents: self = .tableOfContents
+            case .taggingDateTime: self = .taggingDateTime
+            case .time: self = .time
+            case .title: self = .title
+            case .titleSort: self = .titleSort
+            case .trackNumber: self = .trackNumber
+            case .unsynchronizedLyrics(language: _, description: _): self = .unsynchronizedLyrics
+            case .userDefinedText(_): self = .userDefinedText
+            case .userDefinedWebpage(_): self = .userDefinedWebpage
+            case .passThrough(idString: _, uuid: _): self = .passThrough
+            case .year: self = .year
         }
     }
     

--- a/Sources/SwiftTaggerID3/Frame/FrameKey.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameKey.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftLanguageAndLocaleCodes
+import SwiftConvenienceExtensions
 
 /// The unique key used to refer to a particular frame.
 ///
@@ -332,4 +333,196 @@ public enum FrameKey: Hashable {
     case year
     /// any frame not handled by SwiftTagger
     case passThrough(idString: String, uuid: UUID)
+}
+
+extension FrameKey {
+    var upperCasedStringValue: String {
+        self.stringValue.convertCamelToUpperCase()
+            .replacingOccurrences(of: " I D", with: " ID")
+    }
+    
+    var capitalizedStringValue: String {
+        self.stringValue.convertedCamelCase()
+            .replacingOccurrences(of: " I D", with: " ID")
+    }
+    
+    func keyString(format: MetadataExportFormat) -> String {
+        let idString: String
+        let id = FrameIdentifier(frameKey: self)
+
+        if let string = Version.v2_4.idString(id) {
+            idString = string
+        } else if let string = Version.v2_3.idString(id) {
+            idString = string
+        } else if let string = Version.v2_2.idString(id) {
+            idString = string
+        } else {
+            idString = "UNKN"
+        }
+        
+        switch format {
+            case .text: return "(\(idString)) " + upperCasedStringValue
+            default: return idString
+        }
+    }
+    
+    var stringValue: String {
+        switch self {
+            case .album: return "album"
+            case .albumSort: return "albumSort"
+            case .albumArtist: return "albumArtist"
+            case .albumArtistSort: return "albumArtistSort"
+            case .arranger: return "arranger"
+            case .artist: return "artist"
+            case .artistSort: return "artistSort"
+            case .artistWebpage: return "artistWebpage"
+            case .attachedPicture(imageType: let imageType): return "artwork (\(imageType.pictureDescription))"
+            case .audioFileWebpage: return "audioFileWebpage"
+            case .audioSourceWebpage: return "audioSourceWebpage"
+            case .bpm: return "bpm"
+            case .chapter(startTime: let startTime): return "chapter (\(startTime) ms)"
+            case .comments(language: let language, description: let description): return "comment (\(language.isoName), \(description))"
+            case .compilation: return "compilation"
+            case .composer: return "composer"
+            case .composerSort: return "composerSort"
+            case .conductor: return "conductor"
+            case .contentGroup: return "contentGroup"
+            case .copyright: return "copyright"
+            case .copyrightWebpage: return "copyrightWebpage"
+            case .date: return "date"
+            case .discNumber: return "discNumber"
+            case .encodingDateTime: return "encodingDateTime"
+            case .encodedBy: return "encodedBy"
+            case .encodingSettings: return "encodingSettings"
+            case .fileType: return "fileType"
+            case .fileOwner: return "fileOwner"
+            case .genre: return "genre"
+            case .grouping: return "grouping"
+            case .initialKey: return "initialKey"
+            case .involvedPeopleList: return "involvedPeopleList"
+            case .isrc: return "isrc"
+            case .languages: return "languages"
+            case .length: return "length"
+            case .lyricist: return "lyricist"
+            case .mediaType: return "mediaType"
+            case .mood: return "mood"
+            case .movementCount: return "movementCount"
+            case .movement: return "movement"
+            case .movementNumber: return "movementNumber"
+            case .musicianCreditsList: return "musicianCreditsList"
+            case .originalAlbum: return "originalAlbum"
+            case .originalArtist: return "originalArtist"
+            case .originalFilename: return "originalFilename"
+            case .originalLyricist: return "originalLyricist"
+            case .originalReleaseDateTime: return "originalReleaseDateTime"
+            case .paymentWebpage: return "paymentWebpage"
+            case .playlistDelay: return "playlistDelay"
+            case .podcastCategory: return "podcastCategory"
+            case .podcastDescription: return "podcastDescription"
+            case .podcastID: return "podcastID"
+            case .podcastKeywords: return "podcastKeywords"
+            case .podcastFeed: return "podcastFeed"
+            case .producedNotice: return "producedNotice"
+            case .publisher: return "publisher"
+            case .publisherWebpage: return "publisherWebpage"
+            case .radioStation: return "radioStation"
+            case .radioStationOwner: return "radioStationOwner"
+            case .radioStationWebpage: return "radioStationWebpage"
+            case .recordingDateTime: return "recordingDateTime"
+            case .releaseDateTime: return "releaseDateTime"
+            case .setSubtitle: return "setSubtitle"
+            case .subtitle: return "subtitle"
+            case .tableOfContents: return "tableOfContents"
+            case .taggingDateTime: return "taggingDateTime"
+            case .time: return "time"
+            case .title: return "title"
+            case .titleSort: return "titleSort"
+            case .trackNumber: return "trackNumber"
+            case .unsynchronizedLyrics(language: let language, description: let description): return "lyrics (\(language.isoName), \(description))"
+            case .userDefinedText(let string): return string
+            case .userDefinedWebpage(let string): return "Web: \(string)"
+            case .year: return "year"
+            case .passThrough(idString: let idString, uuid: _): return idString
+        }
+    }
+    
+    var priority: Int {
+        switch self {
+            case .bpm: return 35
+            case .compilation: return 12
+            case .playlistDelay: return 34
+            case .movementCount: return 23
+            case .movementNumber: return 22
+            case .mediaType: return 36
+            case .year: return 15
+            case .album: return 1
+            case .albumArtist: return 3
+            case .albumArtistSort: return 4
+            case .albumSort: return 2
+            case .arranger: return 37
+            case .artist: return 8
+            case .artistSort: return 9
+            case .podcastCategory: return 26
+            case .comments(language: _, description: _): return 13
+            case .composer: return 10
+            case .composerSort: return 11
+            case .conductor: return 38
+            case .copyright: return 33
+            case .encodedBy: return 41
+            case .encodingSettings: return 42
+            case .fileType: return 43
+            case .grouping: return 27
+            case .isrc: return 28
+            case .podcastKeywords: return 29
+            case .unsynchronizedLyrics(language: _, description: _): return 47
+            case .lyricist: return 48
+            case .movement: return 21
+            case .originalArtist: return 29
+            case .fileOwner: return 32
+            case .musicianCreditsList: return 40
+            case .involvedPeopleList: return 41
+            case .podcastID: return 14
+            case .podcastFeed: return 25
+            case .genre: return 26
+            case .publisher: return 30
+            case .publisherWebpage: return 31
+            case .recordingDateTime: return 16
+            case .producedNotice: return 39
+            case .releaseDateTime: return 17
+            case .subtitle: return 5
+            case .title: return 6
+            case .titleSort: return 7
+            case .audioSourceWebpage: return 44
+            case .audioFileWebpage: return 45
+            case .contentGroup: return 20
+            case .trackNumber: return 19
+            case .discNumber: return 18
+            case .userDefinedText(_): return 46
+            case .artistWebpage: return 49
+            case .attachedPicture(imageType: _): return 50
+            case .chapter(startTime: _): return 72
+            case .copyrightWebpage: return 66
+            case .date: return 51
+            case .encodingDateTime: return 53
+            case .initialKey: return 54
+            case .languages: return 55
+            case .length: return 56
+            case .mood: return 57
+            case .originalAlbum: return 58
+            case .originalFilename: return 59
+            case .originalLyricist: return 60
+            case .originalReleaseDateTime: return 61
+            case .paymentWebpage: return 62
+            case .podcastDescription: return 63
+            case .radioStation: return 64
+            case .radioStationOwner: return 65
+            case .radioStationWebpage: return 65
+            case .setSubtitle: return 66
+            case .tableOfContents: return 71
+            case .taggingDateTime: return 68
+            case .time: return 52
+            case .userDefinedWebpage(_): return 69
+            case .passThrough(idString: _, uuid: _): return 70
+        }
+    }
 }

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/ChapterFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/ChapterFrame.swift
@@ -33,6 +33,10 @@ public typealias TOC = TableOfContents
 public typealias Chapter = TableOfContents.Chapter
 class ChapterFrame: Frame {
     
+    override var description: String {
+        "Chapter \(startTime.timeStampFromMilliseconds)"
+    }
+    
     /// The Element ID uniquely identifies the frame. It is not intended to be human readable and should not be presented to the end user. Null terminated
     var elementID: String
     
@@ -153,14 +157,9 @@ class ChapterFrame: Frame {
                    size: size,
                    flags: flags)
     }
-    
-    init?() {
-        return nil
-    }
 }
 
 extension Tag {
-    
     var toc: TableOfContents {
         get {
             var chapters = [Chapter]()
@@ -177,7 +176,6 @@ extension Tag {
             chapterList = newValue.chapters
         }
     }
-    
     
     public var chapterList: [Chapter] {
         get {
@@ -235,16 +233,13 @@ extension Tag {
         }
     }
     
-    
     public mutating func addChapter(startTime: Int, title: String) {
         toc.addChapter(startTime: startTime, title: title)
     }
     
-    
     public mutating func removeAllChapters() {
         self.chapterList = []
-    }
-    
+    }    
     
     public mutating func removeChapter(startTime: Int) {
         self.chapterList = self.chapterList.filter({$0.startTime != startTime})

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/ComplexTypesFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/ComplexTypesFrame.swift
@@ -61,7 +61,11 @@
 import Foundation
 /// A type representing a frame with up to three optional strings as content, at least one of which is selected from a preset list of options. This type manages frames `genreType`, `mediaType`, and `fileType`
 class ComplexTypesFrame: Frame {
-
+    
+    override var description: String {
+        contentArray.joined(separator: "; ")
+    }
+    
     var contentArray: [String]
     
     init(identifier: FrameIdentifier,

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/CreditsFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/CreditsFrame.swift
@@ -38,6 +38,18 @@ import Foundation
 ///
 /// Handled as a dictionary: `[role : [array of people performing the role]]`
 class CreditsFrame: Frame {
+    
+    override var description: String {
+        var string = String()
+        let sorted = credits.sorted(by: {$0.key < $1.key})
+        
+        for (key, value) in sorted {
+            let joined = key + ": " + value.joined(separator: "; ")
+            string.append(joined)
+        }
+        return string
+    }
+    
     /// The dictionary of `[role : [array of people performing the role]]`
     var credits: [ String : [String] ]
     

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/DateFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/DateFrame.swift
@@ -74,18 +74,19 @@ import Foundation
 
 @available(OSX 10.12, iOS 12.0, *)
 class DateFrame: Frame {
+
     override var description: String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         formatter.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
         if let date = self.timeStamp {
             let string = formatter.string(from: date)
-            return "\(self.identifier.rawValue): \(string)"
+            return string
         } else {
-            return "\(self.identifier.rawValue): Invalid Date from data \(self.contentData)"
+            return "\(self.identifier.rawValue): Invalid Date"
         }
     }
-
+    
     // MARK: Frame parsing
     // needs to be in ISO-8601 format
     var timeStamp: Date?

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/ImageFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/ImageFrame.swift
@@ -41,6 +41,9 @@ import SwiftConvenienceExtensions
 
 ///  A type representing an ID3 frame that contains an attached image
 class ImageFrame: Frame {
+    override var description: String {
+        descriptionString ?? imageType.pictureDescription
+    }
     
     /// The frame's image contents
     var imageData: Data

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/LocalizedFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/LocalizedFrame.swift
@@ -79,14 +79,9 @@ import SwiftLanguageAndLocaleCodes
 /// `Comment` and `UnsynchronizedLyrics` frames are the only frames that allow the use of new-line characters. Therefore, they are ideally suited for long remarks and convenience getter-setter properties for the most common types have been added.
 class LocalizedFrame: Frame {
     override var description: String {
-        return """
-                Identifier: \(self.identifier.rawValue):
-                Language: \(self.language?.rawValue ?? "und")
-                Description: \(self.descriptionString ?? "")
-                Content: \(self.stringValue)
-                """
+        stringValue
     }
-
+    
     /// ISO-639-2 languge code
     var language: ISO6392Code?
     /// A short description of the frame content.

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/PartAndTotalFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/PartAndTotalFrame.swift
@@ -24,9 +24,17 @@
 import Foundation
 import SwiftConvenienceExtensions
 class PartAndTotalFrame: Frame {
+    
     override var description: String {
-        return "\(self.identifier.rawValue): \(self.part) of \(self.total ?? 0)"
+        let string: String
+        if let total = self.total {
+            string = "\(part)/\(total)"
+        } else {
+            string = String(part)
+        }
+        return string
     }
+    
     /// The index of the track or disc in the set
     var part: Int
     /// The total number of tracks/discs in the set
@@ -57,7 +65,6 @@ class PartAndTotalFrame: Frame {
     }
     
     // MARK: - Frame building
-    ///
     /// Initialize a frame building instance
     /// - parameter part: the index of the track/disc.
     /// - parameter total: the total tracks/discs of the recordings.
@@ -85,12 +92,7 @@ class PartAndTotalFrame: Frame {
     }
 
     override var contentData: Data {
-        var contentString = String()
-        if let total = self.total {
-            contentString = "\(self.part)/\(total)"
-        } else {
-            contentString = String(self.part)
-        }
+        let contentString = description
 
         var data = Data()
         data.append(String.Encoding.isoLatin1.encodingByte)

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/PassThroughFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/PassThroughFrame.swift
@@ -9,6 +9,10 @@ import Foundation
 
 /// a type that passes through any unrecognized or unhandled frame content as-is
 class PassThroughFrame: Frame {
+    override var description: String {
+        "Unhandled Frame (\(identifier.rawValue))"
+    }
+    
     // MARK: - Properties
     var uuid: UUID
     var payload: Data

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/StringFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/StringFrame.swift
@@ -32,6 +32,9 @@ import SwiftLanguageAndLocaleCodes
 ///
 /// Therefore, this frame also handles simple, single-value integer and boolean frames
 class StringFrame: Frame {
+    override var description: String {
+        stringValue
+    }
     /// The contents of the frame, consisting of a single, unterminated string without new lines
     /// This sting may be a URL for an external webpage, or a numeric string for integer and boolean values
     var stringValue: String
@@ -50,9 +53,11 @@ class StringFrame: Frame {
             self.stringValue = try String(ascii: payload)
         } else {
             let encoding = try data.extractEncoding()
-
+            print(encoding.description)
+            
             if identifier == .languages {
                 self.stringValue = data.extractNullTerminatedString(encoding) ?? "und"
+                print(stringValue)
             } else {
                 if identifier.parseAs == .boolean {
                     // since the compilation frame is technically a string frame, it may contain a "boolean-esque" string, like "true" or "yes". We will attempt to catch those cases as well.
@@ -63,6 +68,7 @@ class StringFrame: Frame {
                 }
             }
         }
+
         super.init(identifier: identifier,
                    version: version,
                    size: size,

--- a/Sources/SwiftTaggerID3/Frame/FrameTypes/TableOfContentsFrame.swift
+++ b/Sources/SwiftTaggerID3/Frame/FrameTypes/TableOfContentsFrame.swift
@@ -35,12 +35,15 @@ import Foundation
 ///
 /// However, SwiftTaggerID only supports a single TOC frame, which is assigned a UUID as the elementID. Because of this, the top-level flag will always be true, and SwiftTaggerID3s handling of this frame will ensure the child elements are always ordered, therefore the orderedFlag is also set to true.
 class TableOfContentsFrame: Frame {
+    override var description: String {
+        "Table of Contents"
+    }
+    
     /// the list of all child CTOC and/or CHAP frames, each entry is null-terminated
     var childElementIDs: [String]
     var embeddedSubframesTag: Tag?
     
     // MARK: - Frame parsing initializer
-    
     @available(OSX 10.12, iOS 12.0, *)
     init(identifier: FrameIdentifier,
          version: Version,

--- a/Sources/SwiftTaggerID3/Tag/ImportExport/Export/ExportMetadata.swift
+++ b/Sources/SwiftTaggerID3/Tag/ImportExport/Export/ExportMetadata.swift
@@ -1,0 +1,126 @@
+//
+//  File.swift
+//  
+//
+//  Created by Crystal Wooley on 7/22/21.
+//
+
+import Foundation
+
+extension Tag {
+    public mutating func exportMetadata(
+        file savingAs: MetadataExportFormat,
+        usingFullMetadataForCue: Bool = false) throws {
+        
+        var string = """
+            """
+        switch savingAs {
+            case .csv:
+                string = try formatAsCSV()
+                try string.write(
+                    to: destination(savingAs: savingAs),
+                    atomically: true,
+                    encoding: .utf8)
+            case .json:
+                let data = try formatAsJSON()
+                try data.write(to: destination(savingAs: .json))
+            default:
+                string = formatAsText()
+                try string.write(
+                    to: destination(savingAs: savingAs),
+                    atomically: true,
+                    encoding: .utf8)
+        }
+    }
+    
+    private func destination(savingAs: MetadataExportFormat) -> URL {
+        let fileName = location.fileName
+        
+        return location
+            .deletingPathExtension()
+            .deletingLastPathComponent()
+            .appendingPathComponent(fileName)
+            .appendingPathExtension(savingAs.rawValue)
+    }
+
+    private func getMetadataAsArray(format: MetadataExportFormat) -> [(keyString: String, valueString: String)] {
+        var metadata = [(keyString: String, valueString: String)]()
+        
+        let frames = self.frames
+            .sorted(by: {$0.key.priority < $1.key.priority })
+            .filter({$0.value.identifier != .attachedPicture})
+            .filter({$0.value.identifier != .chapter})
+            .filter({$0.value.identifier != .tableOfContents})
+           
+        for (key, frame) in frames {
+            let keyString = key.keyString(format: format)
+            let valueString = frame.description
+            metadata.append((keyString, valueString))
+        }
+        return metadata
+    }
+    
+    private func getMetadataAsDictionary() throws -> [String: String] {
+        var formatted = [String: String]()
+        for (key, value) in getMetadataAsArray(format: .json) {
+            formatted[key] = value
+        }
+        return formatted
+    }
+    
+    private func formatAsJSON() throws -> Data {
+        let dict = try getMetadataAsDictionary()
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(dict)
+        return data
+    }
+    
+    private func formatAsCSV() throws -> String {
+        var keyString = ""
+        var valueString = ""
+        
+        let dict = try getMetadataAsDictionary()
+        for (key, value) in dict {
+            keyString.append(key + ",")
+            let corrected = value
+                .replacingOccurrences(of: ",", with: ";")
+                .replacingOccurrences(of: "\n", with: "\\")
+                .replacingOccurrences(of: "\u{2117}", with: "(P)")
+                .replacingOccurrences(of: "\u{00A9}", with: "(c)")
+            valueString.append(corrected + ",")
+        }
+        
+        keyString = keyString.trimmingCharacters(in: CharacterSet(charactersIn: ","))
+        valueString = valueString.trimmingCharacters(in: CharacterSet(charactersIn: ","))
+        
+        let string = keyString + "\n" + valueString
+        return string
+    }
+    
+    private func formatAsText() -> String {
+        let metadata = getMetadataAsArray(format: .text)
+        
+        var string = """
+            """
+        
+        var count = 0
+        let sorted = metadata.map({$0.keyString}).sorted(by: {$0.count > $1.count})
+        
+        if let first = sorted.first {
+            count = first.count + 6
+        }
+        
+        for (key, value) in metadata {
+            let difference = count - key.count
+            let separator = ":".padRight(difference)
+            let joined = key + separator + value + "\n"
+            string.append(joined)
+        }
+        return string
+    }
+}
+
+enum ExporterError: Error {
+    case unableToEncodeJSON
+    case unableToWriteJSON
+}

--- a/Sources/SwiftTaggerID3/Tag/ImportExport/ImportExportFormat.swift
+++ b/Sources/SwiftTaggerID3/Tag/ImportExport/ImportExportFormat.swift
@@ -1,0 +1,54 @@
+//
+//  File.swift
+//  
+//
+//  Created by Crystal Wooley on 7/22/21.
+//
+
+public enum MetadataExportFormat: String {
+    /// Exports metadata in a human-readable format
+    case text = "txt"
+    /// Exports metadata in comma-delimited format
+    case csv = "csv"
+    /// Exports metadata in json format
+    case json = "json"
+}
+
+public enum ChapterExportFormat {
+    /// Exports chapters in .cue file format
+    ///
+    /// TITLE "Part 1"
+    /// FILE "file.m4b" M4B
+    /// PERFORMER "Author Name"
+    ///   TRACK 01 AUDIO
+    ///     TITLE "Chapter 1"
+    ///     INDEX 01 00:00:00
+    ///   TRACK 02 AUDIO
+    ///     TITLE "Chapter 2"
+    ///     INDEX 01 11:25:55
+    case cue
+    /// Exports chapters in mp4v2-style format (HH:MM:SS.ZZZ)
+    ///
+    /// 00:00:00.000 Prologue
+    /// 00:00:19.987 Opening
+    /// 00:01:50.160 Episode Blablabla
+    /// 00:21:54.530 Ending
+    /// 00:23:24.453 Preview
+    case mp4v2
+    /**
+     Exports chapters in ogg-style format
+     
+     CHAPTER01=00:00:00.000
+     CHAPTER01NAME=Living Weapon
+     CHAPTER02=00:05:00.750
+     CHAPTER02NAME=A Better World
+     */
+    case ogg
+    
+    var fileExtension: String {
+        switch self {
+            case .cue: return "cue"
+            default: return "txt"
+        }
+    }
+}

--- a/Sources/SwiftTaggerID3/Tag/Tag.swift
+++ b/Sources/SwiftTaggerID3/Tag/Tag.swift
@@ -21,11 +21,13 @@ public struct Tag {
     var version: Version
     var size: Int
     static var duration: Int = 0
+    var location: URL
     
     /// Instantiate a tag by parsing from MP3 file data
     
     @available(OSX 10.12, iOS 12.0, *)
     public init(mp3File: Mp3File) throws {
+        self.location = mp3File.location
         Tag.duration = mp3File.duration
         // get the file data as a subsequence. As the data is parsed when reading a tag, it will be extracted from the subsequence, leaving the remainder instact to continue parsing
         var remainder: Data.SubSequence = mp3File.data[
@@ -74,6 +76,7 @@ public struct Tag {
     init(version: Version, subframes: [FrameKey: Frame]) throws {
         self.version = version
         self.frames = subframes
+        self.location = URL(fileURLWithPath: "")
         var size = Int()
         for (_, frame) in subframes {
             size += frame.encode.count
@@ -89,6 +92,7 @@ public struct Tag {
         self.version = version
         self.frames = [:]
         self.size = 0
+        self.location = URL(fileURLWithPath: "")
     }
     
     // MARK: - Tag Building Calculations

--- a/Tests/SwiftTaggerID3Tests/SwiftTaggerID3_Misc_Tests.swift
+++ b/Tests/SwiftTaggerID3Tests/SwiftTaggerID3_Misc_Tests.swift
@@ -53,7 +53,7 @@ class SwiftTaggerID3_Misc_Tests: XCTestCase {
         tag.title = testString
         tag.titleSort = testString
         
-        //        let outputUrl = tempOutputDirectory
+//        let outputUrl = tempOutputDirectory
         let outputUrl = localOutputDirectory
         XCTAssertNoThrow(try mp3NoMeta.write(tag: &tag,
                                              version: .v2_4,
@@ -107,8 +107,8 @@ class SwiftTaggerID3_Misc_Tests: XCTestCase {
         tag[lyrics: testString, .eng] = testString
         tag[testString] = testString
 
-        //        let outputUrl = tempOutputDirectory
-        let outputUrl = localOutputDirectory
+        let outputUrl = tempOutputDirectory
+//        let outputUrl = localOutputDirectory
         XCTAssertNoThrow(try mp3NoMeta.write(tag: &tag,
                                              version: .v2_4,
                                              outputLocation: outputUrl))
@@ -158,8 +158,8 @@ class SwiftTaggerID3_Misc_Tests: XCTestCase {
         tag.title = testString
         tag.titleSort = testString
                 
-        //let outputUrl = tempOutputDirectory
-        let outputUrl = localOutputDirectory
+        let outputUrl = tempOutputDirectory
+//        let outputUrl = localOutputDirectory
         XCTAssertNoThrow(try mp3NoMeta.write(tag: &tag, version: .v2_3, outputLocation: outputUrl))
         
         let outputMp3 = try Mp3File(location: outputUrl)
@@ -229,8 +229,8 @@ class SwiftTaggerID3_Misc_Tests: XCTestCase {
         tag.title = testString
         tag.titleSort = testString
         
-        //let outputUrl = tempOutputDirectory
-        let outputUrl = localOutputDirectory
+        let outputUrl = tempOutputDirectory
+//        let outputUrl = localOutputDirectory
         XCTAssertNoThrow(try mp3NoMeta.write(tag: &tag, version: .v2_2, outputLocation: outputUrl))
         
         let outputMp3 = try Mp3File(location: outputUrl)


### PR DESCRIPTION
One of my tests is failing, but I can't figure out where exactly it's going wrong, because the error message doesn't point out specifically where the problem is happening.

This is the message I'm getting:

> XCTAssertNoThrow failed: throwing "*** -[NSRegularExpression enumerateMatchesInString:options:range:usingBlock:]: Range or index out of bounds"

I assume it refers to one of these two extensions of string, the second of which is an all-caps variation on [this](https://stackoverflow.com/a/50202999/12199136).

```swift
    func convertCamelCase() -> String {
        return self
            .replacingOccurrences(of: " ", with: "")
            .replacingOccurrences(of: "([A-Z])",
                                  with: " $1",
                                  options: .regularExpression,
                                  range: range(of: self))
            .capitalized
    }

    func convertCamelToUpperCase() -> String {
        return self
            .replacingOccurrences(of: " ", with: "")
            .replacingOccurrences(of: "([A-Z])",
                                  with: " $1",
                                  options: .regularExpression,
                                  range: range(of: self))
            .uppercased()
    }
```

The context for this is that I'm trying to convert my frame keys to a human-readable string that can be exported to a text file to display all the metadata, but a string which can be easily parsed if I import metadata from that same text file, like this:

[output.txt](https://github.com/NCrusher74/SwiftTaggerID3/files/6874584/output.txt)

The parts on the right are the values of the actual frames (some of which have been massaged via `CustomStringConvertible` to make them readable.

The parts to the left side are a version of the frameKey that is also massaged to be human-readable. Since `FrameKey` cannot conform to `String` (on account of some frame keys having associated values) I implemented a `stringValue` property for them:

```swift
    var stringValue: String {
        switch self {
            case .album: return "album"
            case .albumSort: return "albumSort"
            case .albumArtist: return "albumArtist"
            // ...
```

And then I convert that `stringValue` to all caps and pretty it up a bit:

```swift
    var upperCasedStringValue: String {
        self.stringValue.convertCamelToUpperCase()
        .replacingOccurrences(of: " I D", with: " ID")
        .replacingOccurrences(of: "U R L", with: "URL")
        .replacingOccurrences(of: "  ", with: " ")
    }
```

And combine it with the frame identifier to create the string seen in the file above:

```swift
    func keyString(format: MetadataExportFormat) -> String {
        let idString: String
        let id = FrameIdentifier(frameKey: self)

        if let string = Version.v2_4.idString(id) {
            idString = string
        } else if let string = Version.v2_3.idString(id) {
            idString = string
        } else if let string = Version.v2_2.idString(id) {
            idString = string
        } else {
            idString = "UNKN"
        }
        
        switch format {
            case .text: return "{\(idString)} " + upperCasedStringValue
            default: return idString
        }
    }
```

Upon import of a text file formatted like this, the part in the brackets is really all I'm concerned with, except when it comes to frames that have an associated language and/or description as part of their frame key. Which is where my problem is.

```swift
            case .comments(language: let language, description: let description):
                if description != "" && language != .und {
                    return "[\(language.rawValue)] \(description.camelCased)"
                } else if description != "" && language == .und {
                    return description.camelCased
                } else if description == "" && language != .und {
                    return "[\(language.rawValue)]"
                } else {
                    return "Comment"
                }
```

Because the `language` and `description` values are optional in the frame itself, but I don't want to make them optional in the `FrameKey` enum, I assign them a default value of `.und` and `""`. So when trying to create a human-readable string out of these, I have four different possibilities:

1) There's no language or description, so I don't need a human-readable string for them, and I just substitute in the default "Comment" descriptor.
2) There's a language but no description
3) There's a description but no language
4) Both are present

In order to parse this information from an imported file, I have to have some way of differentiating whether the string is a language raw value, or whether it's a description, so I put the language in square brackets.

I suspect those are what is breaking my extension, but I'm not sure what I should do about it.

instead of converting the `stringValue` for that case to upper case after the fact, I guess I could do it in a case-by-case basis to avoid running the square brackets through my extension, but that seems really inefficient:

```swift
            case .bpm: return "bpm".convertCamelToUpperCase()
            case .comments(language: let language, description: let description):
                if description != "" && language != .und {
                    return "[\(language.rawValue.uppercased())] \(description.uppercased())"
                } else if description != "" && language == .und {
                    return description.uppercased()
                } else if description == "" && language != .und {
                    return "[\(language.rawValue.uppercased())]"
                } else {
                    return "Comment".uppercased()
                }
            case .compilation: return "compilation".convertCamelToUpperCase()
```

There has to be a more efficient way than what I'm doing?